### PR TITLE
Add an option to load the schema from a yaml file instead of disk

### DIFF
--- a/src/com/instaclustr/sstabletools/PurgeStatisticsCollector.java
+++ b/src/com/instaclustr/sstabletools/PurgeStatisticsCollector.java
@@ -3,8 +3,12 @@ package com.instaclustr.sstabletools;
 import com.google.common.collect.MinMaxPriorityQueue;
 import com.google.common.util.concurrent.RateLimiter;
 import com.instaclustr.sstabletools.cassandra.CassandraBackend;
+import com.instaclustr.sstabletools.cassandra.CassandraSchema;
 import org.apache.commons.cli.*;
+import org.yaml.snakeyaml.Yaml;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.util.*;
 
 /**
@@ -17,6 +21,7 @@ public class PurgeStatisticsCollector {
     private static final String SNAPSHOT_OPTION = "t";
     private static final String FILTER_OPTION = "f";
     private static final String BATCH_OPTION = "b";
+    private static final String SCHEMA_OPTION = "s";
 
     private static final Options options = new Options();
     private static CommandLine cmd;
@@ -43,6 +48,9 @@ public class PurgeStatisticsCollector {
 
         Option optBatch = new Option(BATCH_OPTION, "batch", false, "Batch mode");
         options.addOption(optBatch);
+
+        Option optSchema = new Option(SCHEMA_OPTION, "schema", true, "Load the schema from a YAML definition instead of from disk");
+        options.addOption(optSchema);
     }
 
     private static void printHelp() {
@@ -101,11 +109,19 @@ public class PurgeStatisticsCollector {
                 interactive = false;
             }
 
+            CassandraSchema schema = null;
+            if (cmd.hasOption(SCHEMA_OPTION)) {
+                File file = new File(cmd.getOptionValue(SCHEMA_OPTION));
+                FileInputStream fileInputStream = new FileInputStream(file);
+
+                schema = new Yaml().loadAs(fileInputStream, CassandraSchema.class);
+            }
+
             args = cmd.getArgs();
             String ksName = args[0];
             String cfName = args[1];
 
-            cfProxy = CassandraBackend.getInstance().getColumnFamily(ksName, cfName, snapshotName, filter);
+            cfProxy = CassandraBackend.getInstance(schema).getColumnFamily(ksName, cfName, snapshotName, filter);
             PurgeStatisticsReader reader = cfProxy.getPurgeStatisticsReader(rateLimiter);
 
             long totalSize = 0;

--- a/src/com/instaclustr/sstabletools/SSTableMetadataCollector.java
+++ b/src/com/instaclustr/sstabletools/SSTableMetadataCollector.java
@@ -1,8 +1,12 @@
 package com.instaclustr.sstabletools;
 
 import com.instaclustr.sstabletools.cassandra.CassandraBackend;
+import com.instaclustr.sstabletools.cassandra.CassandraSchema;
 import org.apache.commons.cli.*;
+import org.yaml.snakeyaml.Yaml;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.util.*;
 
 /**
@@ -10,6 +14,7 @@ import java.util.*;
  */
 public class SSTableMetadataCollector {
     private static final String HELP_OPTION = "h";
+    private static final String SCHEMA_OPTION = "s";
 
     private static final Options options = new Options();
     private static CommandLine cmd;
@@ -17,6 +22,11 @@ public class SSTableMetadataCollector {
     private static void printHelp() {
         HelpFormatter formatter = new HelpFormatter();
         formatter.printHelp("ic-sstables <keyspace> <columnFamily>", "Print out metadata for sstables the belong to a column family", options, null);
+    }
+
+    static {
+        Option optSchema = new Option(SCHEMA_OPTION, "schema", true, "Load the schema from a YAML definition instead of from disk");
+        options.addOption(optSchema);
     }
 
     public static void main(String[] args) {
@@ -38,6 +48,14 @@ public class SSTableMetadataCollector {
             if (cmd.getArgs().length != 2) {
                 printHelp();
                 System.exit(1);
+            }
+
+            CassandraSchema schema = null;
+            if (cmd.hasOption(SCHEMA_OPTION)) {
+                File file = new File(cmd.getOptionValue(SCHEMA_OPTION));
+                FileInputStream fileInputStream = new FileInputStream(file);
+
+                schema = new Yaml().loadAs(fileInputStream, CassandraSchema.class);
             }
 
             args = cmd.getArgs();
@@ -63,7 +81,7 @@ public class SSTableMetadataCollector {
                     "Droppable",
                     "Repaired At"
             );
-            List<SSTableMetadata> metadataCollection = CassandraBackend.getInstance().getSSTableMetadata(ksName, cfName);
+            List<SSTableMetadata> metadataCollection = CassandraBackend.getInstance(schema).getSSTableMetadata(ksName, cfName);
             Collections.sort(metadataCollection, SSTableMetadata.TIMESTAMP_COMPARATOR);
             for (SSTableMetadata metadata : metadataCollection) {
                 tb.addRow(

--- a/src/com/instaclustr/sstabletools/cassandra/CassandraBackend.java
+++ b/src/com/instaclustr/sstabletools/cassandra/CassandraBackend.java
@@ -1,16 +1,22 @@
 package com.instaclustr.sstabletools.cassandra;
 
+import com.google.common.collect.Maps;
 import com.instaclustr.sstabletools.CassandraProxy;
 import com.instaclustr.sstabletools.ColumnFamilyProxy;
 import com.instaclustr.sstabletools.SSTableMetadata;
 import com.instaclustr.sstabletools.Util;
+import com.instaclustr.sstabletools.cassandra.CassandraSchema.ColumnFamily;
 import org.apache.cassandra.config.CFMetaData;
+import org.apache.cassandra.config.KSMetaData;
 import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.locator.SimpleStrategy;
 import org.apache.cassandra.utils.EstimatedHistogram;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,18 +27,45 @@ import java.util.*;
  * Proxy to Cassandra 2.2 backend.
  */
 public class CassandraBackend implements CassandraProxy {
-    private static final CassandraBackend singleton = new CassandraBackend();
+    private static final Logger logger = LoggerFactory.getLogger(CassandraBackend.class);
 
-    public static CassandraProxy getInstance() {
+    private static CassandraBackend singleton = null;
+
+    public static CassandraProxy getInstance(CassandraSchema schema) {
+        if (singleton == null) {
+            singleton = new CassandraBackend(schema);
+        }
         return singleton;
     }
 
     static {
         org.apache.cassandra.tools.Util.initDatabaseDescriptor();
-        Schema.instance.loadFromDisk(false);
     }
 
-    private CassandraBackend() {
+    private CassandraBackend(CassandraSchema schema) {
+        if (schema == null) {
+            Schema.instance.loadFromDisk(false);
+        } else {
+            for (CassandraSchema.Keyspace keyspace : schema.keyspaces) {
+                List<CFMetaData> cfDefs = new ArrayList<>();
+
+                for (ColumnFamily columnFamily : keyspace.columnFamilies) {
+                    CFMetaData cfMetaData = CFMetaData.compile(columnFamily.cql, keyspace.name);
+                    cfDefs.add(cfMetaData);
+
+                    logger.warn("Loading column family {} with id {}", cfMetaData.cfName, cfMetaData.cfId.toString().replace("-", ""));
+                }
+
+                HashMap<String, String> options = Maps.newHashMap();
+                options.put("replication_factor", "1");
+
+                logger.warn("Adding {} column families to keyspace {}", cfDefs.size(), keyspace.name);
+
+                KSMetaData ksMetaData = KSMetaData.newKeyspace(keyspace.name, SimpleStrategy.class, options, false, cfDefs);
+
+                Schema.instance.addKeyspace(ksMetaData);
+            }
+        }
     }
 
     public List<String> getKeyspaces() {

--- a/src/com/instaclustr/sstabletools/cassandra/CassandraSchema.java
+++ b/src/com/instaclustr/sstabletools/cassandra/CassandraSchema.java
@@ -1,0 +1,26 @@
+package com.instaclustr.sstabletools.cassandra;
+
+import java.util.List;
+
+public class CassandraSchema {
+    public List<Keyspace> keyspaces;
+
+    public CassandraSchema() {
+    }
+
+    public static class Keyspace {
+        public String name;
+        public List<ColumnFamily> columnFamilies;
+
+        public Keyspace() {
+        }
+    }
+
+    public static class ColumnFamily {
+        public String cql;
+
+        public ColumnFamily(String cql) {
+            this.cql = cql;
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I've discovered these tools last week and while very useful, I wanted to analyze data on a cluster that is quite tight in resources and both `ic-cfstats` or `ic-purge` had too much impact on the node.

To get around this, I implemented a way to provide the schema via a configuration file defining the tables instead of loading from disk.

Additionally this allows me to snapshot a table on the node, rsync the snapshots to another server and run the analysis there: no need to add extra load on the node.

This configuration file is a simple yaml file that can be provided with the `-s` or `--schema` flag:

    ic-cfstats -s ./config.yml mydata user_history

And the file looks like this:

    keyspaces:
    - name: mydata
      columnFamilies:
      - |
        CREATE TABLE mydata.user_history (
            id uuid PRIMARY KEY,
    	name text,
    	age int,
        ) WITH 
            AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
            AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
    
      - |
        CREATE TABLE mydata.users (
            app_id uuid,
    	user_id uuid,
    	PRIMARY KEY ((app_id), user_id)
        ) WITH CLUSTERING ORDER BY (user_id ASC)
            AND compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
            AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};

It's not a small change so I'm open to suggestions, but so far it works great for my use case.