### PR TITLE
add a build target to generate IntelliJ IDEA files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -32,10 +32,10 @@
             <available file="${cassandra.dir}" type="dir"/>
         </condition>
     </target>
-    
+
     <target name="download" depends="cassandra-check" unless="cassandra.exists">
         <mkdir dir="${cassandra.download.dir}"/>
-        <get src="http://archive.apache.org/dist/cassandra/${cassandra.version}/apache-cassandra-${cassandra.version}-bin.tar.gz" dest="${cassandra.download.dir}" skipexisting="true"/>        
+        <get src="http://archive.apache.org/dist/cassandra/${cassandra.version}/apache-cassandra-${cassandra.version}-bin.tar.gz" dest="${cassandra.download.dir}" skipexisting="true"/>
     </target>
 
     <target name="extract" depends="cassandra-check, download" unless="cassandra.exists">
@@ -55,4 +55,22 @@
         <jar destfile="${jar.dir}/ic-sstable-tools.jar" basedir="${classes.dir}"/>
     </target>
 
+    <!-- Generate IDEA project description files -->
+    <target name="generate-idea-files" depends="extract" description="Generate IDEA files">
+        <mkdir dir=".idea"/>
+        <mkdir dir=".idea/libraries"/>
+        <copy todir=".idea">
+            <fileset dir="ide/idea"/>
+        </copy>
+        <copy tofile="cassandra-sstable-tools.iml" file="ide/idea-iml-file.xml"/>
+        <echo file=".idea/.name">Cassandra SSTable Tools</echo>
+        <echo file=".idea/modules.xml"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+    <component name="ProjectModuleManager">
+    <modules>
+        <module fileurl="file://$PROJECT_DIR$/cassandra-sstable-tools.iml" filepath="$PROJECT_DIR$/cassandra-sstable-tools.iml" />
+    </modules>
+</component>
+    </project>]]></echo>
+    </target>
 </project>

--- a/ide/idea-iml-file.xml
+++ b/ide/idea-iml-file.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module type="JAVA_MODULE" version="4">
+    <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
+        <output url="file://$MODULE_DIR$/.idea/out/main" />
+        <output-test url="file://$MODULE_DIR$/.idea/out/test" />
+        <exclude-output />
+        <content url="file://$MODULE_DIR$">
+            <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+            <excludeFolder url="file://$MODULE_DIR$/.idea" />
+            <excludeFolder url="file://$MODULE_DIR$/.settings" />
+            <excludeFolder url="file://$MODULE_DIR$/build" />
+        </content>
+        <orderEntry type="inheritedJdk" />
+        <orderEntry type="sourceFolder" forTests="false" />
+        <orderEntry type="module-library">
+            <library>
+                <CLASSES>
+                    <root url="file://$MODULE_DIR$/cassandra/2.2.14/lib" />
+                </CLASSES>
+                <jarDirectory url="file://$MODULE_DIR$/cassandra/2.2.14/lib" recursive="false" />
+                <JAVADOC />
+            </library>
+        </orderEntry>
+    </component>
+</module>

--- a/ide/idea/ant.xml
+++ b/ide/idea/ant.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AntConfiguration">
+    <buildFile url="file://$PROJECT_DIR$/build.xml" />
+  </component>
+</project>

--- a/ide/idea/vcs.xml
+++ b/ide/idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Hi,

this PR adds a ant build target `generate-idea-files` so that it's easy to start working on the code with IntelliJ IDEA by just opening the directory, libraries and source directories will be setup correctly.

I based it on the existing `generate-idea-files` in the cassandra repository with a lot of extra things removed.

I tested it on IDEA 2019.1.3, it seems to work well.