### PR TITLE
Use distributedKeyspaces

### DIFF
--- a/src/main/java/com/instaclustr/sstabletools/cassandra/CassandraBackend.java
+++ b/src/main/java/com/instaclustr/sstabletools/cassandra/CassandraBackend.java
@@ -9,6 +9,7 @@ import org.apache.cassandra.db.compaction.DateTieredCompactionStrategy;
 import org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
+import org.apache.cassandra.locator.LocalStrategy;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.TableMetadata;
@@ -46,6 +47,7 @@ public class CassandraBackend implements CassandraProxy {
     public List<String> getKeyspaces() {
         return Schema.instance.distributedKeyspaces()
                 .stream()
+                .filter(keyspace -> keyspace.params.replication.klass != LocalStrategy.class)
                 .map(ksmd -> ksmd.name)
                 .sorted()
                 .collect(Collectors.toList());

--- a/src/main/java/com/instaclustr/sstabletools/cassandra/CassandraBackend.java
+++ b/src/main/java/com/instaclustr/sstabletools/cassandra/CassandraBackend.java
@@ -3,8 +3,6 @@ package com.instaclustr.sstabletools.cassandra;
 import com.instaclustr.sstabletools.CassandraProxy;
 import com.instaclustr.sstabletools.ColumnFamilyProxy;
 import com.instaclustr.sstabletools.SSTableMetadata;
-import org.apache.cassandra.schema.TableMetadata;
-import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.compaction.DateTieredCompactionStrategy;
@@ -12,16 +10,21 @@ import org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy;
 import org.apache.cassandra.io.sstable.Component;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.schema.KeyspaceMetadata;
+import org.apache.cassandra.schema.Schema;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.tools.Util;
 import org.apache.cassandra.utils.EstimatedHistogram;
-
-import static com.instaclustr.sstabletools.Util.NOW_SECONDS;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.instaclustr.sstabletools.Util.NOW_SECONDS;
 
 /**
  * Proxy to Cassandra 4.1 backend.
@@ -41,9 +44,11 @@ public class CassandraBackend implements CassandraProxy {
     private CassandraBackend() {}
 
     public List<String> getKeyspaces() {
-        return Schema.instance.getNonLocalStrategyKeyspaces()
-                     .stream()
-                     .map(ksmd -> ksmd.name).sorted().collect(Collectors.toList());
+        return Schema.instance.distributedKeyspaces()
+                .stream()
+                .map(ksmd -> ksmd.name)
+                .sorted()
+                .collect(Collectors.toList());
     }
 
     public List<String> getColumnFamilies(String ksName) {


### PR DESCRIPTION
Context:
Between the release of 4.1.3 and 4.1.4 a [commit](https://github.com/instaclustr/cassandra/commit/ac71d0f56efda081cf3c602eae8897b64cf84dac#diff-7c6186d9bdaa4d0b04fdcd15ccb1144473d3ca0b723e715dffc86d4bddb6d1c7) was made in the upstream Cassandra repo that removed the `Schema#getNonLocalStrategyKeyspaces()` method. Essentially this just returns all keyspaces except the ones that use local strategy replication.

So we need to replace the usage of `getNonLocalStrategyKeyspaces` with `Schema#distributedKeyspaces()` and filter manually to ensure 1:1 behaviour.